### PR TITLE
Update StorageUnits.cs

### DIFF
--- a/Ps3DiscDumper/Utils/StorageUnits.cs
+++ b/Ps3DiscDumper/Utils/StorageUnits.cs
@@ -2,19 +2,19 @@
 {
     public static class StorageUnits
     {
-        private const long UnderKB = 1000;
-        private const long UnderMB = 1000 * 1024;
-        private const long UnderGB = 1000 * 1024 * 1024;
+        private const long UnderKiB = 1024;
+        private const long UnderMiB = 1024 * 1024;
+        private const long UnderGiB = 1024 * 1024 * 1024;
 
         public static string AsStorageUnit(this long bytes)
         {
-            if (bytes < UnderKB)
+            if (bytes < UnderKiB)
                 return $"{bytes} byte{(bytes == 1 ? "" : "s")}";
-            if (bytes < UnderMB)
-                return $"{bytes / 1024.0:0.##} KB";
-            if (bytes < UnderGB)
-                return $"{bytes / 1024.0 / 1024:0.##} MB";
-            return $"{bytes / 1024.0 / 1024 / 1024:0.##} GB";
+            if (bytes < UnderMiB)
+                return $"{bytes / 1024.0:0.##} KiB";
+            if (bytes < UnderGiB)
+                return $"{bytes / 1024.0 / 1024:0.##} MiB";
+            return $"{bytes / 1024.0 / 1024 / 1024:0.##} GiB";
         }
     }
 }


### PR DESCRIPTION
[Sorry, I couldn't resist :P](https://en.wikipedia.org/wiki/Binary_prefix)

On a more serious note, I'm fine with either of the nomenclatures, but mixing them is not a good idea. And by that I mean that you filled in 1000 as the kilobyte limit, but used 1024 everywhere else, including where the actual counting happened. This resulted in 1000 bytes being printed out as "0.97 KB", which I'm fairly sure was not the design goal, even if you prefer KB' over KiB'.

I'm also not terribly sure why haven't you just casted the limits to doubles and used them for the divisions, or better yet, just made them doubles to begin with, but what do I know ¯\_(ツ)_/¯. I did correct all the output strings to use binary prefixes though, but if you don't like them, I'll revert those gladly.

:popcorn: