### PR TITLE
Add support for source file command line option

### DIFF
--- a/Ps3DiscDumper/Dumper.cs
+++ b/Ps3DiscDumper/Dumper.cs
@@ -151,27 +151,34 @@ namespace Ps3DiscDumper
             Log.Info($"Game title: {Title}");
         }
 
-        public void DetectDisc(Func<Dumper, string> outputDirFormatter = null)
+        public void DetectDisc(string inDir = "", Func<Dumper, string> outputDirFormatter = null)
         {
             outputDirFormatter = outputDirFormatter ?? (d => $"[{d.ProductCode}] {d.Title}");
             string discSfbPath = null;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                var drives = DriveInfo.GetDrives().Where(d => d.DriveType == DriveType.CDRom && d.IsReady);
-                foreach (var drive in drives)
+                if (!String.IsNullOrEmpty(inDir))
+                    discSfbPath = Path.Combine(inDir, "PS3_DISC.SFB");
+                else
                 {
-                    discSfbPath = Path.Combine(drive.Name, "PS3_DISC.SFB");
-                    if (!File.Exists(discSfbPath))
-                        continue;
+                    var drives = DriveInfo.GetDrives().Where(d => d.DriveType == DriveType.CDRom && d.IsReady);
+                    foreach (var drive in drives)
+                    {
+                        discSfbPath = Path.Combine(drive.Name, "PS3_DISC.SFB");
+                        if (!File.Exists(discSfbPath))
+                            continue;
 
-                    Drive = drive.Name[0];
-                    input = drive.Name;
-                    break;
+                        Drive = drive.Name[0];
+                        input = drive.Name;
+                        break;
+                    }
                 }
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                discSfbPath = IOEx.GetFilepaths("/media", "PS3_DISC.SFB", 2).FirstOrDefault();
+                if (String.IsNullOrEmpty(inDir))
+                    inDir = "/media";
+                discSfbPath = IOEx.GetFilepaths(inDir, "PS3_DISC.SFB", 2).FirstOrDefault();
                 if (!string.IsNullOrEmpty(discSfbPath))
                     input = Path.GetDirectoryName(discSfbPath);
             }

--- a/Ps3DiscDumper/Dumper.cs
+++ b/Ps3DiscDumper/Dumper.cs
@@ -157,26 +157,33 @@ namespace Ps3DiscDumper
             string discSfbPath = null;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                if (!String.IsNullOrEmpty(inDir))
-                    discSfbPath = Path.Combine(inDir, "PS3_DISC.SFB");
-                else
+                var drives = DriveInfo.GetDrives().Where(d => d.DriveType == DriveType.CDRom && d.IsReady);
+                if (string.IsNullOrEmpty(inDir))
                 {
-                    var drives = DriveInfo.GetDrives().Where(d => d.DriveType == DriveType.CDRom && d.IsReady);
                     foreach (var drive in drives)
                     {
                         discSfbPath = Path.Combine(drive.Name, "PS3_DISC.SFB");
                         if (!File.Exists(discSfbPath))
                             continue;
 
-                        Drive = drive.Name[0];
                         input = drive.Name;
+                        Drive = drive.Name[0];
                         break;
+                    }
+                }
+                else
+                {
+                    discSfbPath = Path.Combine(inDir, "PS3_DISC.SFB");
+                    if (File.Exists(discSfbPath))
+                    {
+                        input = Path.GetPathRoot(discSfbPath);
+                        Drive = discSfbPath[0];
                     }
                 }
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                if (String.IsNullOrEmpty(inDir))
+                if (string.IsNullOrEmpty(inDir))
                     inDir = "/media";
                 discSfbPath = IOEx.GetFilepaths(inDir, "PS3_DISC.SFB", 2).FirstOrDefault();
                 if (!string.IsNullOrEmpty(discSfbPath))

--- a/UI.Console.Msil/UI.Console.Msil.csproj
+++ b/UI.Console.Msil/UI.Console.Msil.csproj
@@ -85,6 +85,9 @@
     <PackageReference Include="Microsoft.AspNet.WebApi.Client">
       <Version>5.2.7</Version>
     </PackageReference>
+    <PackageReference Include="Mono.Options">
+      <Version>5.3.0.1</Version>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>12.0.2</Version>
     </PackageReference>

--- a/UI.Console/Program.cs
+++ b/UI.Console/Program.cs
@@ -1,15 +1,15 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using NDesk.Options;
 using IrdLibraryClient;
+using Mono.Options;
 using Ps3DiscDumper;
 
 namespace UIConsole
 {
     internal static class Program
     {
-        static async Task Main(string[] args)
+        static async Task<int> Main(string[] args)
         {
             Log.Info("PS3 Disc Dumper v" + Dumper.Version);
             var lastDiscId = "";
@@ -17,16 +17,49 @@ start:
             const string titleBase = "PS3 Disc Dumper";
             var title = titleBase;
             Console.Title = title;
+            var output = ".";
+            var inDir = "";
+            var showHelp = false;
+            var options = new OptionSet
+            {
+                {
+                    "i|input=", "Path to the root of blu-ray disc mount", v =>
+                    {
+                        if (v is string ind)
+                            inDir = ind;
+                    }
+                },
+                {
+                    "o|output=", "Path to the output folder. Subfolder for each disc will be created automatically", v =>
+                    {
+                        if (v is string outd)
+                            output = outd;
+                    }
+                },
+                {
+                    "?|h|help", "Show help", v =>
+                    {
+                        if (v != null)
+                            showHelp = true;
+                    },
+                    true
+                },
+            };
             try
             {
-                var output = ".";
-                var inDir = "";
-                var options = new OptionSet()
+                var unknownParams = options.Parse(args);
+                if (unknownParams.Count > 0)
                 {
-                    { "i=", v => { inDir = v; }},
-                    { "o=", v => { output = v; }}
-                };
-                options.Parse(args);
+                    Log.Warn("Unknown parameters: ");
+                    foreach (var p in unknownParams)
+                        Log.Warn("\t" + p);
+                    showHelp = true;
+                }
+                if (showHelp)
+                {
+                    ShowHelp(options);
+                    return 0;
+                }
 
                 var dumper = new Dumper(ApiConfig.Cts);
                 dumper.DetectDisc(inDir);
@@ -34,7 +67,7 @@ start:
                 if (string.IsNullOrEmpty(dumper.OutputDir))
                 {
                     Log.Info("No compatible disc was found, exiting");
-                    return;
+                    return 2;
                 }
                 if (lastDiscId == dumper.ProductCode)
                 {
@@ -91,10 +124,8 @@ start:
             }
             catch (OptionException e)
             {
-                Console.Write("Command line error: ");
-                Console.WriteLine(e.Message);
-                Console.WriteLine("Usage: dotnet run [-i input dir] [-o output dir]");
-                Environment.Exit(1);
+                ShowHelp(options);
+                return 1;
             }
             catch (Exception e)
             {
@@ -105,10 +136,17 @@ start:
             switch (key.Key)
             {
                 case ConsoleKey.X:
-                    return;
+                    return 0;
                 default:
                     goto start;
             }
+        }
+
+        private static void ShowHelp(OptionSet options)
+        {
+            Console.WriteLine("Usage: dotnet run [UI.Console.csproj]");
+            Console.WriteLine("Supported arguments:");
+            options.WriteOptionDescriptions(Console.Out);
         }
     }
 }

--- a/UI.Console/Program.cs
+++ b/UI.Console/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using NDesk.Options;
 using IrdLibraryClient;
 using Ps3DiscDumper;
 
@@ -18,15 +19,17 @@ start:
             Console.Title = title;
             try
             {
-                if (args.Length > 1)
+                var output = ".";
+                var inDir = "";
+                var options = new OptionSet()
                 {
-                    Console.WriteLine("Expected one arguments: output folder");
-                    return;
-                }
+                    { "i=", v => { inDir = v; }},
+                    { "o=", v => { output = v; }}
+                };
+                options.Parse(args);
 
-                var output = args.Length == 1 ? args[0] : ".";
                 var dumper = new Dumper(ApiConfig.Cts);
-                dumper.DetectDisc();
+                dumper.DetectDisc(inDir);
                 await dumper.FindDiscKeyAsync(ApiConfig.IrdCachePath).ConfigureAwait(false);
                 if (string.IsNullOrEmpty(dumper.OutputDir))
                 {
@@ -85,6 +88,13 @@ start:
                     Console.WriteLine("Dump is valid");
                     Console.ResetColor();
                 }
+            }
+            catch (OptionException e)
+            {
+                Console.Write("Command line error: ");
+                Console.WriteLine(e.Message);
+                Console.WriteLine("Usage: dotnet run [-i input dir] [-o output dir]");
+                Environment.Exit(1);
             }
             catch (Exception e)
             {

--- a/UI.Console/UI.Console.csproj
+++ b/UI.Console/UI.Console.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="1.0.0-alpha-*" />
-    <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
+    <PackageReference Include="Mono.Options" Version="5.3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/UI.Console/UI.Console.csproj
+++ b/UI.Console/UI.Console.csproj
@@ -31,6 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="1.0.0-alpha-*" />
+    <PackageReference Include="NDesk.Options.Core" Version="1.2.5" />
   </ItemGroup>
 
 </Project>

--- a/UI.WinForms.Msil/Forms/MainForm.cs
+++ b/UI.WinForms.Msil/Forms/MainForm.cs
@@ -271,7 +271,8 @@ namespace UI.WinForms.Msil
             var dumper = (Dumper)doWorkEventArgs.Argument;
             try
             {
-                dumper.DetectDisc(d =>
+                dumper.DetectDisc("",
+                    d =>
                                   {
                                       var items = new NameValueCollection
                                       {


### PR DESCRIPTION
pls no bully

I tested ripping a pair of games at "/mnt" and it worked fine.

closes #2 
(This should have been closed a while ago tbh, its worked on linux for a while. But now the discussion is also addressed.)