### PR TITLE
Linux build via Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,6 @@ There are different ways to get the dumper work:
   * `$ git clone https://github.com/13xforever/ps3-disc-dumper.git`
   * `$ cd UI.Console`
   * `$ dotnet run`
+* Alternative: Linux build via Docker
+  * run `docker-compose up`
+  * the executable should then be available at `./UI.Console/bin/Release/net6.0/linux-x64/ps3-disc-dumper`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.5"
+
+services:
+
+  ps3dd:
+    image: ubuntu:21.04
+    volumes:
+      - .:/ps3-disc-dumper
+    # compare: https://docs.microsoft.com/en-us/dotnet/core/install/linux-ubuntu
+    entrypoint: >
+      bash -c "
+      apt-get update &&
+      apt-get install -y wget apt-transport-https &&
+      wget https://packages.microsoft.com/config/ubuntu/21.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb &&
+      dpkg -i packages-microsoft-prod.deb && 
+      apt-get update &&
+      apt-get install -y dotnet-sdk-6.0 &&
+      cd /ps3-disc-dumper/UI.Console &&
+      dotnet publish --configuration Release --runtime linux-x64 --self-contained true
+      "


### PR DESCRIPTION
This will make it easier to build the executable under Linux by utilizing an Ubuntu image and the official Microsoft dotnet installation procedure; keeping the host system free of all these dependencies.