### PR TITLE
Fix code signing and version on macOS published build.

### DIFF
--- a/UI.Avalonia/UI.Avalonia.csproj
+++ b/UI.Avalonia/UI.Avalonia.csproj
@@ -33,7 +33,8 @@
         <CFBundleName>PS3 Disc Dumper</CFBundleName>
         <CFBundleDisplayName>PS3 Disc Dumper</CFBundleDisplayName>
         <CFBundleIdentifier>com.github.13xforever.ps3-disc-dumper</CFBundleIdentifier>
-        <CFBundleShortVersionString>4.1.4</CFBundleShortVersionString>
+        <CFBundleVersion>4.1.4</CFBundleVersion>
+        <CFBundleShortVersionString>$(CFBundleVersion)</CFBundleShortVersionString>
         <CFBundleExecutable>ps3-disc-dumper</CFBundleExecutable>
         <CFBundleIconFile>icon.icns</CFBundleIconFile>
     </PropertyGroup>

--- a/publish-mac.ps1
+++ b/publish-mac.ps1
@@ -14,17 +14,21 @@ Remove-Item -LiteralPath UI.Avalonia/obj -Recurse -Force -ErrorAction SilentlyCo
 
 Write-Host 'Building macOS binary...' -ForegroundColor Cyan
 dotnet publish -v:q -t:BundleApp -r osx-arm64 -f net8.0 --self-contained -c MacOS -o distrib/gui/mac/ UI.Avalonia/UI.Avalonia.csproj /p:PublishTrimmed=False /p:PublishSingleFile=True
-if (($LASTEXITCODE -eq 0) -and ($IsMacOS -or ($PSVersionTable.Platform -eq 'Unix')))
-{
-    chmod +x distrib/gui/mac/ps3-disc-dumper
-}
 
 Write-Host 'Clearing extra files in distrib...' -ForegroundColor Cyan
 Get-ChildItem -LiteralPath distrib -Include *.pdb,*.config -Recurse | Remove-Item
 
-Write-Host 'Bundling...' -ForegroundColor Cyan
-if (Test-Path -LiteralPath distrib/gui/mac/ps3-disc-dumper)
+if (($LASTEXITCODE -eq 0) -and ($IsMacOS -or ($PSVersionTable.Platform -eq 'Unix')))
 {
+    chmod +x distrib/gui/mac/ps3-disc-dumper
+    # The final app bundle needs to be re-signed as a whole.
+    codesign --deep -fs - 'distrib/gui/mac/PS3 Disc Dumper.app'
+}
+
+Write-Host 'Bundling...' -ForegroundColor Cyan
+if (Test-Path -LiteralPath 'distrib/gui/mac/PS3 Disc Dumper.app')
+{
+    # tar to preserve file permissions.
     tar -C distrib/gui/mac -cvzf distrib/ps3-disc-dumper_macos_NEW.tar.gz 'PS3 Disc Dumper.app'
 }
 


### PR DESCRIPTION
Did some testing with a basic GitHub Actions workflow [here](https://github.com/Steveice10/ps3-disc-dumper/actions/runs/7862054400) to make sure there wouldn't be any issues with building and publishing Mac builds, since apps built on your own system are treated differently.

Identified three issues that are fixed by this PR:
* `CFBundleShortVersionString` was set but not `CFBundleVersion`, so the bundler was setting them to two different versions.
* Code signature was being invalidated by deleting `pdb` and `config` files; it needs to be resigned afterwards.
* The path test for taring was checking for the unbundled executable instead of the `.app` bundle. This didn't actually cause any issues since both paths exist, but it's more correct to fix that.

After fixing these issues, the artifacts from my basic GitHub Actions workflow can be run on my system with no modifications.