### PR TITLE
MacOS Arm64 updated library names to be prefixed with /System/Library/Frameworks/

### DIFF
--- a/Ps3DiscDumper/Utils/MacOS/CoreFoundation.cs
+++ b/Ps3DiscDumper/Utils/MacOS/CoreFoundation.cs
@@ -9,8 +9,8 @@ namespace Ps3DiscDumper.Utils.MacOS;
 [SupportedOSPlatform("osx")]
 public static partial class CoreFoundation
 {
-    private const string AsLibraryName = "ApplicationServices.framework/ApplicationServices";
-    private const string CfLibraryName = "CoreFoundation.framework/CoreFoundation";
+    private const string AsLibraryName = "/System/Library/Frameworks/ApplicationServices.framework/Versions/Current/ApplicationServices";
+    private const string CfLibraryName = "/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation";
     private const string CfLibraryPath = "/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation";
 
     public const uint KernSuccess = 0;

--- a/Ps3DiscDumper/Utils/MacOS/DiskArbitration.cs
+++ b/Ps3DiscDumper/Utils/MacOS/DiskArbitration.cs
@@ -8,7 +8,7 @@ namespace Ps3DiscDumper.Utils.MacOS;
 [SupportedOSPlatform("osx")]
 public static partial class DiskArbitration
 {
-    private const string LibraryName = "DiskArbitration.framework/DiskArbitration";
+    private const string LibraryName = "/System/Library/Framework/DiskArbitration.framework/DiskArbitration";
 
     public static readonly IntPtr DescriptionMediaKindKey = CoreFoundation.__CFStringMakeConstantString("DAMediaKind");
 

--- a/Ps3DiscDumper/Utils/MacOS/IOKit.cs
+++ b/Ps3DiscDumper/Utils/MacOS/IOKit.cs
@@ -8,7 +8,7 @@ namespace Ps3DiscDumper.Utils.MacOS;
 [SupportedOSPlatform("osx")]
 public static partial class IOKit
 {
-    private const string LibraryName = "IOKit.framework/IOKit";
+    private const string LibraryName = "/System/Library/Frameworks/IOKit.framework/Versions/Current/IOKit";
 
     public static readonly IntPtr MasterPortDefault = IntPtr.Zero;
     public const string BdMediaClass = "IOBDMedia";
@@ -20,7 +20,7 @@ public static partial class IOKit
     public static partial IntPtr IOServiceMatching(string name);
 
     [LibraryImport(LibraryName), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial uint IOServiceGetMatchingServices(IntPtr mainPort, IntPtr matching, out IntPtr existing);
+    public static partial int IOServiceGetMatchingServices(IntPtr mainPort, IntPtr matching, out IntPtr existing);
 
     [LibraryImport(LibraryName), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial IntPtr IOIteratorNext(IntPtr iterator);


### PR DESCRIPTION
On apple silicon the importing  without the fully path causes system exceptions. I've updated to use the full path.