### PR TITLE
fixes bad library name for added prefix

### DIFF
--- a/Ps3DiscDumper/Utils/MacOS/DiskArbitration.cs
+++ b/Ps3DiscDumper/Utils/MacOS/DiskArbitration.cs
@@ -8,7 +8,7 @@ namespace Ps3DiscDumper.Utils.MacOS;
 [SupportedOSPlatform("osx")]
 public static partial class DiskArbitration
 {
-    private const string LibraryName = "/System/Library/Framework/DiskArbitration.framework/DiskArbitration";
+    private const string LibraryName = "/System/Library/Frameworks/DiskArbitration.framework/DiskArbitration";
 
     public static readonly IntPtr DescriptionMediaKindKey = CoreFoundation.__CFStringMakeConstantString("DAMediaKind");
 


### PR DESCRIPTION
The library for DiskArbitration was incorrect i've renamed and tested on macos m1 max